### PR TITLE
Origin/gameplay fixes

### DIFF
--- a/Assets/DataItems/GameStateData/GameStateData.asset
+++ b/Assets/DataItems/GameStateData/GameStateData.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: GameStateData
   m_EditorClassIdentifier: 
   numHumansRequiredToBeatFirstMilestone: 10
-  nextMilestoneIncrement: 10
+  nextMilestoneIncrement: 2
   numPlanetsDiscoveredPerMilestone: 1

--- a/Assets/DataItems/GameStateData/GameStateData.cs
+++ b/Assets/DataItems/GameStateData/GameStateData.cs
@@ -17,9 +17,9 @@ public class GameStateData : ScriptableObject
     // THIS IS ALL WIP FUNCTIONALITY
     public void Tick()
     {
-        if (GameManager.Instance.ResourceManager.GetGlobalResourceAmount(ResourceNames.HUMAN) > currentMilestone)
+        if (GameManager.Instance.ResourceManager.GetGlobalResourceAmount(ResourceNames.HUMAN) >= currentMilestone)
         {
-            currentMilestone = currentMilestone * nextMilestoneIncrement;
+            currentMilestone = Mathf.Round(currentMilestone * nextMilestoneIncrement);
             GameManager.Instance.PlanetManager.InstantiatePlanets(numPlanetsDiscoveredPerMilestone);
         }
     }

--- a/Assets/DataItems/Shuttle/ShuttleRouteData.cs
+++ b/Assets/DataItems/Shuttle/ShuttleRouteData.cs
@@ -28,7 +28,7 @@ public class ShuttleRouteData : ScriptableObject
         endPlanetData = _endPlanetData;
         resourceToShipName = _resourceToShipName;
         amount = _amount;
-        shuttleTravelDuration = Vector3.Distance(startPlanetData.PlanetPosition, endPlanetData.PlanetPosition) * 0.75f;
+        shuttleTravelDuration = Vector3.Distance(startPlanetData.PlanetPosition, endPlanetData.PlanetPosition) * 0.1f * amount;
     }
 
     public void Tick()

--- a/Assets/Scripts/ShuttleConfirmationPanel.cs
+++ b/Assets/Scripts/ShuttleConfirmationPanel.cs
@@ -48,7 +48,7 @@ public class ShuttleConfirmationPanel : MonoBehaviour
 
     void Update()
     {
-        amountToShip = (int) (amountSlider.value * 25.0f);
+        amountToShip = (int) (amountSlider.value * 24.0f) + 1;
         amountTMP.text = amountToShip.ToString();
     }
 


### PR DESCRIPTION
Some miscellaneous fixes

GameStateData.asset
- Reduced milestone increment multiplier from 10 to 2

ShuttleConfirmationPanel.cs
- Prevented the player from being able to send 0 shuttles during confirmation

ShuttleRouteData.cs
- the speed of a shuttle is now dependent on the amount transported

GameStateData.cs
- currentMilestone is rounded to prevent decimal amounts of people
- a planet is now created when there are equal people to the currentMilestone requirement as well as if there are greater than the amount of people